### PR TITLE
🔒 [security] fix path traversal in skill upload

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -12,7 +12,7 @@ import { getToolDefinitions } from '../tools/registry.js';
 import os from 'os';
 import { execSync } from 'child_process';
 import { readdirSync, statSync, rmSync, mkdirSync, existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { join, basename } from 'path';
 import multer from 'multer';
 import AdmZip from 'adm-zip';
 
@@ -215,7 +215,14 @@ router.post('/skills/upload', upload.single('file'), (req, res) => {
     const entries = zip.getEntries();
     // Determine skill name from zip
     const firstDir = entries.find(e => e.isDirectory);
-    const skillName = firstDir ? firstDir.entryName.split('/')[0] : req.file.originalname.replace(/\.zip$/i, '');
+    let skillName = firstDir ? firstDir.entryName.split('/')[0] : req.file.originalname.replace(/\.zip$/i, '');
+
+    // Sanitize skillName to prevent path traversal
+    skillName = basename(skillName);
+    if (!skillName || skillName === '.' || skillName === '..') {
+      return res.status(400).json({ error: 'Invalid skill name' });
+    }
+
     const extractTo = join(skillsDir, skillName);
     if (!existsSync(extractTo)) mkdirSync(extractTo, { recursive: true });
     zip.extractAllTo(extractTo, true);


### PR DESCRIPTION
This PR fixes a path traversal vulnerability in the skill upload endpoint (`/skills/upload`). 

Previously, the skill name was derived from either a directory name inside the uploaded ZIP file or the ZIP file's original name without proper sanitization. This allowed an attacker to provide a malicious name (e.g., `../../evil`) to extract files outside of the intended `skills` directory.

The fix involves:
1. Importing `basename` from the `path` module.
2. Wrapping the derived `skillName` with `basename()` to strip any directory traversal sequences.
3. Adding a check to ensure the resulting `skillName` is valid (not empty, `.`, or `..`).

Verified the fix with a reproduction script that attempted various traversal payloads.

---
*PR created automatically by Jules for task [13855796533176873386](https://jules.google.com/task/13855796533176873386) started by @OmYarewar*