### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in DELETE /skills/:name

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-15 - Fixed Path Traversal in Skill Deletion
+**Vulnerability:** A critical path traversal vulnerability existed in `DELETE /skills/:name` where `req.params.name` was not sanitized before joining with `skillsDir`. An attacker could exploit this to delete arbitrary files on the filesystem.
+**Learning:** File path inputs from user requests (e.g. `req.params`, `req.body`, `req.query`) must always be sanitized when used in operations involving the filesystem like `rmSync` or `readFileSync`.
+**Prevention:** Always use `path.basename()` or strictly validate paths to ensure they stay within intended directory bounds before file operations.

--- a/server/memory/store.test.js
+++ b/server/memory/store.test.js
@@ -41,7 +41,7 @@ describe('Database Store Initialization', () => {
   test('initDB should set foreign_keys pragma', () => {
     const db = initDB(':memory:');
 
-    const foreignKeys = db.pragma('foreign_keys');
+    const foreignKeys = db.pragma('foreign_keys', { simple: true });
     assert.strictEqual(foreignKeys, 1);
   });
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -237,10 +237,15 @@ router.post('/skills/upload', upload.single('file'), (req, res) => {
 router.delete('/skills/:name', (req, res) => {
   try {
     const skillsDir = getSkillsDir();
-    const skillPath = join(skillsDir, req.params.name);
+    // Sanitize skillName to prevent path traversal
+    const safeName = basename(req.params.name);
+    if (!safeName || safeName === '.' || safeName === '..') {
+      return res.status(400).json({ error: 'Invalid skill name' });
+    }
+    const skillPath = join(skillsDir, safeName);
     if (existsSync(skillPath)) {
       rmSync(skillPath, { recursive: true, force: true });
-      res.json({ success: true, message: `Skill "${req.params.name}" deleted` });
+      res.json({ success: true, message: `Skill "${safeName}" deleted` });
     } else {
       res.status(404).json({ error: 'Skill not found' });
     }


### PR DESCRIPTION
- Added `basename()` sanitization to `req.params.name` in `DELETE /skills/:name` inside `server/routes/api.js` to prevent critical path traversal vulnerabilities that could allow arbitrary file deletion.
- Added `{ simple: true }` when calling `db.pragma('foreign_keys')` in `server/memory/store.test.js` to correctly return the scalar `1` as expected by the assertion.
- Add finding to `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [14730569024670051403](https://jules.google.com/task/14730569024670051403) started by @OmYarewar*